### PR TITLE
Added link to PostgresSql setup guide

### DIFF
--- a/docs/development/getting-started/installation-guide.md
+++ b/docs/development/getting-started/installation-guide.md
@@ -85,7 +85,7 @@ Open the package.json file and add the following scripts:
 
 ### Step 3: Run the installation script
 
-Before running this script, make sure that you have an empty Postgres database ready for EverShop.
+Before running this script, make sure that you have an empty Postgres database ready for EverShop. If you need help setting up a PostgreSQL database, please refer to the [PostgreSQL setup guide](/docs/development/knowledge-base/database.md) for detailed instructions
 
 :::info
 Please check [this document](/docs/development/getting-started/system-requirements) for the system requirements list.


### PR DESCRIPTION
### Summary:
This pull request updates the documentation for setting up EverShop by adding a link to guide users on how to set up an empty PostgreSQL database. Previously, it was mentioned that a PostgreSQL database was needed, but no link or further instructions were provided.

### Changes:
- Added a reference to a PostgreSQL setup guide in the installation steps.

.

Please review and let me know if any adjustments are needed.
