### PR TITLE
#11 - doc - centralize Node version & NPM version

### DIFF
--- a/docs/_const.md
+++ b/docs/_const.md
@@ -1,0 +1,2 @@
+export const nodeVersionSupport = { "min": "18.17.0", "max": "20.18.2" };
+export const npmVersionSupport = { "min": "9", "max": "10.0.0" };

--- a/docs/development/deployment/deploy-evershop-to-aws.md
+++ b/docs/development/deployment/deploy-evershop-to-aws.md
@@ -6,6 +6,7 @@ sidebar_label: Deploy EverShop To AWS
 title: Deploy EverShop To AWS
 description: This document describes step by step how to deploy EverShop to AWS using AWS EC2 and AWS RDS.
 ---
+import { nodeVersionSupport, npmVersionSupport } from '../../_const.md';
 
 # Deploy EverShop to AWS
 
@@ -33,7 +34,7 @@ sudo apt update
 sudo apt install nodejs npm
 ```
 
-EverShop requires node.js version 14 or higher. Npm version 8 or higher is also required.
+Evershop requires Node.js version between **{nodeVersionSupport.min}** and **{nodeVersionSupport.max}**, and Npm version **{npmVersionSupport.min}** or higher.
 
 ### Install PM2
 

--- a/docs/development/deployment/deploy-evershop-to-heroku.md
+++ b/docs/development/deployment/deploy-evershop-to-heroku.md
@@ -6,6 +6,8 @@ sidebar_label: Deploy EverShop To Heroku
 title: Deploy EverShop To Heroku
 description: This document describes step by step how to deploy EverShop to Heroku.
 ---
+import CodeBlock from '@theme/CodeBlock'
+import { nodeVersionSupport, npmVersionSupport } from '../../_const.md';
 
 # Deploy EverShop To Heroku
 
@@ -118,27 +120,32 @@ Typically, the EverShop project structure will look like this:
 
 ### Specify The Node.js Version
 
+Evershop requires Node.js version between **{nodeVersionSupport.min}** and **{nodeVersionSupport.max}**.
 Heroku will let us specify the Node.js version that we want to use in the `package.json` file. We need to add the following line to the `package.json` file:
 
-```json title="package.json"
+<CodeBlock language="json" title="package.json">
 {
-  "engines": {
-    "node": "18.x"
-  }
+  `{
+    "engines": {
+      "node": "${nodeVersionSupport.min.split('.')[0]}.x"
+    }
+  }`
 }
-```
+</CodeBlock>
 
 ### Specify The NPM Version
 
-EverShop requires NPM version 8+. We need to add the following line to the `package.json` file:
+EverShop requires NPM version **{npmVersionSupport.min}+**. We need to add the following line to the `package.json` file:
 
-```json title="package.json"
+<CodeBlock language="json" title="package.json">
 {
-  "engines": {
-    "npm": "9.x"
-  }
+  `{
+    "engines": {
+      "npm": "${npmVersionSupport.min}.x"
+    }
+  }`
 }
-```
+</CodeBlock>
 
 ### Specify The Start Script
 

--- a/docs/development/getting-started/system-requirements.md
+++ b/docs/development/getting-started/system-requirements.md
@@ -6,6 +6,7 @@ sidebar_label: System requirements
 title: System requirements.
 description: EverShop system requirements. The full list of requirements that you need to check your system before installing EverShop.
 ---
+import { nodeVersionSupport, npmVersionSupport } from '../../_const.md';
 
 # System requirements
 
@@ -18,11 +19,11 @@ EverShop can run on Windows, Linux or Mac-OS.
 
 ## Node.js
 
-To install EverShop, you must have [Node.js](https://nodejs.org/en/) version 18.17.0 or above.
+To install EverShop, you must have [Node.js](https://nodejs.org/en/) version between **{nodeVersionSupport.min}** and **{nodeVersionSupport.max}** (which can be checked by running `node -v`).
 
 ## NPM
 
-[NPM](https://www.npmjs.com/) version 7 or higher (which can be checked by running `node -v`).
+[NPM](https://www.npmjs.com/) version between **{npmVersionSupport.min}** or higher (which can be checked by running `npm -v`).
 
 ## Database
 


### PR DESCRIPTION
* Centralize supported Node version
* Update the max Node version support in document (currently Node >20 removed some Utils API that break `evershop`)