### PR TITLE
Update cart.md

### DIFF
--- a/docs/api/cart.md
+++ b/docs/api/cart.md
@@ -217,7 +217,7 @@ Use this endpoint to add customer email to cart.
 
 <Api
   method="POST"
-  url="/api/cart/{id}/contacts"
+  url="/api/carts/{id}/contacts"
   requestSchema={{
   "type": "object",
   "properties": {
@@ -251,7 +251,7 @@ Use this endpoint to add address (Billing or Shipping) to cart.
 
 <Api
   method="POST"
-  url="/api/cart/{id}/addresses"
+  url="/api/carts/{id}/addresses"
   requestSchema={{
   "type": "object",
   "properties": {
@@ -343,7 +343,7 @@ Use this endpoint to add shipping method to cart.
 
 <Api
   method="POST"
-  url="/api/cart/{id}/shippingMethods"
+  url="/api/carts/{id}/shippingMethods"
   requestSchema={{
   "type": "object",
   "properties": {
@@ -385,7 +385,7 @@ Use this endpoint to add payment method to cart.
 
 <Api
   method="POST"
-  url="/api/cart/{id}/paymentMethods"
+  url="/api/carts/{id}/paymentMethods"
   requestSchema={{
   "type": "object",
   "properties": {


### PR DESCRIPTION
fix(docs): update API endpoints to use plural form 'carts' instead of 'cart'

Corrected API documentation to reflect actual working endpoints in Evershop:
- Changed:
  - /api/cart/{id}/contacts       ➜ /api/carts/{id}/contacts
  - /api/cart/{id}/addresses      ➜ /api/carts/{id}/addresses
  - /api/cart/{id}/shippingMethods ➜ /api/carts/{id}/shippingMethods
  - /api/cart/{id}/paymentMethods ➜ /api/carts/{id}/paymentMethods

Tested all endpoints with Postman to confirm that the plural form 'carts' is required. See Evershop API reference